### PR TITLE
Update oval_org.cisecurity_tst_892.xml

### DIFF
--- a/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_892.xml
+++ b/repository/tests/windows/file_test/0000/oval_org.cisecurity_tst_892.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if ogl.dll version is less than 4.0.7577.4498" id="oval:org.cisecurity:tst:892" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:24009" />
+  <object object_ref="oval:org.mitre.oval:obj:38846" />
   <state state_ref="oval:org.cisecurity:ste:725" />
 </file_test>


### PR DESCRIPTION
Updated referenced object from oval:org.mitre.oval:obj:24009 to oval:org.mitre.oval:obj:38846.
