### PR TITLE
Updated oval:org.mitre.oval:tst:100081

### DIFF
--- a/repository/tests/windows/registry_test/100000/oval_org.mitre.oval_tst_100081.xml
+++ b/repository/tests/windows/registry_test/100000/oval_org.mitre.oval_tst_100081.xml
@@ -1,3 +1,3 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if HKLM\Software\Mozilla\Mozilla Firefox.*$!Install Directory exists" id="oval:org.mitre.oval:tst:100081" version="4">
-  <object object_ref="oval:org.mitre.oval:obj:30212" />
+  <object object_ref="oval:org.cisecurity:obj:338" />
 </registry_test>


### PR DESCRIPTION
Updated oval:org.mitre.oval:tst:100081 to check both 32 and 64 bit.
