### PR TITLE
Deprecate Tests and States for CVE-2017-2982, 4

### DIFF
--- a/repository/states/windows/file_state/2000/oval_org.cisecurity_ste_2036.xml
+++ b/repository/states/windows/file_state/2000/oval_org.cisecurity_ste_2036.xml
@@ -1,3 +1,3 @@
-<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 24.0.0.221" id="oval:org.cisecurity:ste:2036" version="1">
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 24.0.0.221" deprecated="true" id="oval:org.cisecurity:ste:2036" version="1">
   <version datatype="version" operation="less than">24.0.0.221</version>
 </file_state>

--- a/repository/states/windows/registry_state/2000/oval_org.cisecurity_ste_2035.xml
+++ b/repository/states/windows/registry_state/2000/oval_org.cisecurity_ste_2035.xml
@@ -1,3 +1,3 @@
-<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 24.0.0.221" id="oval:org.cisecurity:ste:2035" version="1">
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches version less than 24.0.0.221" deprecated="true" id="oval:org.cisecurity:ste:2035" version="1">
   <value datatype="version" operation="less than">24.0.0.221</value>
 </registry_state>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2603.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2603.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Pepper Flash for Google Chrome version is less than 24.0.0.221" id="oval:org.cisecurity:tst:2603" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Pepper Flash for Google Chrome version is less than 24.0.0.221" deprecated="true" id="oval:org.cisecurity:tst:2603" version="2">
   <object object_ref="oval:org.cisecurity:obj:176" />
   <state state_ref="oval:org.cisecurity:ste:2036" />
 </file_test>

--- a/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2605.xml
+++ b/repository/tests/windows/file_test/2000/oval_org.cisecurity_tst_2605.xml
@@ -1,4 +1,4 @@
-<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Flash*.ocx version is less than 24.0.0.221" id="oval:org.cisecurity:tst:2605" version="2">
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if Flash*.ocx version is less than 24.0.0.221" deprecated="true" id="oval:org.cisecurity:tst:2605" version="2">
   <object object_ref="oval:org.mitre.oval:obj:41861" />
   <state state_ref="oval:org.cisecurity:ste:2036" />
 </file_test>

--- a/repository/tests/windows/registry_test/2000/oval_org.cisecurity_tst_2604.xml
+++ b/repository/tests/windows/registry_test/2000/oval_org.cisecurity_tst_2604.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Adobe Flash Player version is less than 24.0.0.221" id="oval:org.cisecurity:tst:2604" version="1">
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if Adobe Flash Player version is less than 24.0.0.221" deprecated="true" id="oval:org.cisecurity:tst:2604" version="1">
   <object object_ref="oval:org.mitre.oval:obj:7290" />
   <state state_ref="oval:org.cisecurity:ste:2035" />
 </registry_test>


### PR DESCRIPTION
Deprecate Tests and States for CVE-2017-2982
(oval:org.cisecurity:def:1869), and CVE-2017-2984
(oval:org.cisecurity:def:1870) since the issue has already been fixed.